### PR TITLE
ignore minor versions in example yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Specifies which Erlang runtime to use. The following runtimes are available:
 ```yaml
 run.config:
   engine.config:
-    erlang_runtime: erlang-20.0
+    erlang_runtime: erlang-20
 ```
 
 ## Help & Support


### PR DESCRIPTION
This removes the minor version so that as 20.1, 20.2, etc get released the runtime will be updated with it.