### PR TITLE
Copy symbolic links as directories for release

### DIFF
--- a/lib/elixir.sh
+++ b/lib/elixir.sh
@@ -4,7 +4,7 @@
 # Copy the compiled jars into the app directory to run live
 publish_release() {
 	nos_print_bullet "Moving build into live app directory..."
-	rsync -a $(nos_code_dir)/ $(nos_app_dir)
+	rsync -a -k $(nos_code_dir)/ $(nos_app_dir)
 }
 
 # Determine the elixir runtime to install. This will first check
@@ -38,7 +38,7 @@ default_erlang_runtime() {
 # Install the elixir and erlang runtime along with any dependencies.
 install_runtime_packages() {
   pkgs=("$(erlang_runtime)" "$(runtime)")
-  
+
   # add any client dependencies
   pkgs+=("$(query_dependencies)")
 
@@ -53,11 +53,11 @@ install_helper_scripts() {
 	nos_template_file \
 		'bin/node-start' \
 		$(nos_data_dir)/bin/node-start
-		
+
 	nos_template_file \
 		'bin/node-attach' \
 		$(nos_data_dir)/bin/node-attach
-		
+
 	# chmod them
 	chmod +x $(nos_data_dir)/bin/node-start
 	chmod +x $(nos_data_dir)/bin/node-attach
@@ -94,7 +94,7 @@ query_dependencies() {
 	if [[ `grep 'red\|yar\|verk' $(nos_code_dir)/mix.exs` ]]; then
 		deps+=(redis)
 	fi
-  
+
   echo "${deps[@]}"
 }
 


### PR DESCRIPTION
`build_embedded: true` is no longer default on Mix projects. So `priv` directories inside `_build` are still symbolically linked to `priv` directories of each Erlang/Elixir app respectively.

This will cause crashes in production if only `_build` is made writable after deployment and any app tries to write to its own `priv` directory.

This fix adds `-k` to `rsync` so symbolically linked directories are copied during release, effectively forcing `build_embedded: true` always.