### PR TITLE
Add node-stop helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When preparing your runtime, this engine compiles code by doing the following:
 This engine provides helper scripts to make managing your Elixir application easier.
 
 ### node-attach
-The `node-attach` helper facilitates connecting to an Elixir node that was started with `elixir-start`.
+The `node-attach` helper facilitates connecting to an Elixir node that was started with `node-start`.
 
 ```bash
 node-attach
@@ -38,6 +38,13 @@ The `node-start` helper ensures that nodes are started with credentials sufficie
 # Examples
 node-start mix phoenix.server
 node-start mix run —no-halt
+```
+
+### node-stop
+The `node-stop` helper ensures that an Elixir node started with `node-start` is stopped gracefully.
+
+```bash
+node-stop
 ```
 
 ## Configuration Options

--- a/files/bin/node-attach
+++ b/files/bin/node-attach
@@ -1,11 +1,11 @@
 #!/bin/bash
-# 
+#
 # A simple wrapper to facilitate connecting to an elixir
-# node that was started with `elixir-start`
-# 
+# node that was started with `node-start`
+#
 # Usage:
 # node-attach
-# 
+#
 
 # exit if any any command fails
 set -e

--- a/files/bin/node-stop
+++ b/files/bin/node-stop
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# A simple wrapper to facilitate stopping an elixir node that was
+# started with `node-start`
+#
+# Usage:
+# node-stop
+#
+
+# exit if any any command fails
+set -e
+
+# establish the name and cookie (if available)
+name="stop@$(hostname -i)"
+cookie="${COOKIE:-nanobox}"
+remote="${HOSTNAME//./-}@$(hostname -i)"
+
+elixir \
+  --name $name \
+  --cookie $cookie \
+  -e ":rpc.call(:\"$remote\", :init, :stop, [])"


### PR DESCRIPTION
Run `node-stop` to gracefully shutdown.

Some OTP apps start external programs (ports, monitoring agents, etc.) that need to be gracefully shut down by the OTP apps themselves.

The current `pkill -U gonano -SIGTERM` command in the stop hook prevents proper cleanup and triggers unnecessary warnings.